### PR TITLE
Update Kotlin to 1.2.50 (with workarounds)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,9 +33,29 @@ android {
         versionName "0.1.2"
     }
     buildTypes {
+        debug {
+            // Temporary workaround for Kotlin 1.2.50 and DataBinding bug. For more context see
+            // https://issuetracker.google.com/issues/110198434 and
+            // https://youtrack.jetbrains.com/issue/KT-24915#comment=27-2914947
+            tasks.whenTaskAdded { task ->
+                if (task.name == 'kaptDebugKotlin') {
+                    task.dependsOn dataBindingExportFeaturePackageIdsDebug
+                }
+            }
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+
+            // Temporary workaround for Kotlin 1.2.50 and DataBinding bug. For more context see
+            // https://issuetracker.google.com/issues/110198434 and
+            // https://youtrack.jetbrains.com/issue/KT-24915#comment=27-2914947
+            tasks.whenTaskAdded { task ->
+                if (task.name == 'kaptReleaseKotlin') {
+                    task.dependsOn dataBindingExportFeaturePackageIdsRelease
+                }
+            }
         }
     }
     compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
         junitVersion = '4.12'
         lifecycleVersion = '1.1.1'
         navigationVersion = '1.0.0-alpha02'
-        kotlinVersion = '1.2.41'
+        kotlinVersion = '1.2.50'
         ktxVersion = '0.3'
         roomVersion = '1.1.0'
         runnerVersion = '1.0.1'


### PR DESCRIPTION
This change includes a temporary workaround for a Kotlin 1.2.50 and DataBinding bug.

For more context see https://issuetracker.google.com/issues/110198434 and https://youtrack.jetbrains.com/issue/KT-24915#comment=27-2914947