### PR TITLE
Update Android Gradle Plugin to 3.2.0-beta02

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,29 +34,9 @@ android {
         vectorDrawables.useSupportLibrary true
     }
     buildTypes {
-        debug {
-            // Temporary workaround for Kotlin 1.2.50 and DataBinding bug. For more context see
-            // https://issuetracker.google.com/issues/110198434 and
-            // https://youtrack.jetbrains.com/issue/KT-24915#comment=27-2914947
-            tasks.whenTaskAdded { task ->
-                if (task.name == 'kaptDebugKotlin') {
-                    task.dependsOn dataBindingExportFeaturePackageIdsDebug
-                }
-            }
-        }
-
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-
-            // Temporary workaround for Kotlin 1.2.50 and DataBinding bug. For more context see
-            // https://issuetracker.google.com/issues/110198434 and
-            // https://youtrack.jetbrains.com/issue/KT-24915#comment=27-2914947
-            tasks.whenTaskAdded { task ->
-                if (task.name == 'kaptReleaseKotlin') {
-                    task.dependsOn dataBindingExportFeaturePackageIdsRelease
-                }
-            }
         }
     }
     compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         dataBindingVersion = '3.0.1'
         espressoVersion = '3.0.1'
         glideVersion = '4.4.0'
-        gradleVersion = '3.2.0-beta01'
+        gradleVersion = '3.2.0-beta02'
         gsonVersion = '2.8.2'
         junitVersion = '4.12'
         lifecycleVersion = '1.1.1'


### PR DESCRIPTION
This PR also removes the temporary workaround for https://issuetracker.google.com/issues/110198434.

Fixes https://github.com/googlesamples/android-sunflower/issues/67