### PR TITLE
Fix #75:  an approach to handle duplicated "appbar"

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/Extensions.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/Extensions.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower
+
+import android.support.annotation.AnimRes
+import android.view.View
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+
+fun View.fadeOut(@AnimRes anim: Int = android.R.anim.fade_out, fadeOutEnd: View.() -> Unit = {}) =
+    apply {
+        with(AnimationUtils.loadAnimation(context, anim)) {
+            setAnimationListener(object : Animation.AnimationListener {
+                override fun onAnimationEnd(animation: Animation) {
+                    fadeOutEnd(this@fadeOut)
+                }
+
+                override fun onAnimationRepeat(animation: Animation) {
+                }
+
+                override fun onAnimationStart(animation: Animation) {
+                }
+            })
+            startAnimation(this)
+        }
+    }
+
+fun View.fadeIn(@AnimRes anim: Int = android.R.anim.fade_in, fadeOutEnd: View.() -> Unit = {}) = apply {
+    with(AnimationUtils.loadAnimation(context, anim)) {
+        setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationEnd(animation: Animation) {
+                fadeOutEnd(this@fadeIn)
+            }
+
+            override fun onAnimationRepeat(animation: Animation) {
+            }
+
+            override fun onAnimationStart(animation: Animation) {
+            }
+        })
+        startAnimation(this)
+    }
+}

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenActivity.kt
@@ -18,11 +18,10 @@ package com.google.samples.apps.sunflower
 
 import android.databinding.DataBindingUtil
 import android.os.Bundle
-import android.support.design.widget.NavigationView
 import android.support.v4.widget.DrawerLayout
 import android.support.v7.app.AppCompatActivity
-import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import androidx.navigation.Navigation
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
@@ -47,6 +46,14 @@ class GardenActivity : AppCompatActivity() {
 
         // Set up navigation menu
         binding.navigationView.setupWithNavController(navController)
+
+        navController.addOnNavigatedListener { _, destination ->
+            if (destination.id == R.id.plant_detail_fragment) {
+                binding.appbar.fadeOut { visibility = View.GONE }
+            } else {
+                binding.appbar.fadeIn { visibility = View.VISIBLE }
+            }
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -21,11 +21,10 @@ import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
-import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-
+import androidx.navigation.Navigation
 import com.google.samples.apps.sunflower.databinding.FragmentPlantDetailBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
 import com.google.samples.apps.sunflower.viewmodels.PlantDetailViewModel
@@ -54,7 +53,10 @@ class PlantDetailFragment : Fragment() {
                 plantDetailViewModel.addPlantToGarden()
                 Snackbar.make(view, R.string.added_plant_to_garden, Snackbar.LENGTH_LONG).show()
             }
-        }
+        }.also { it.detailToolbar.setNavigationOnClickListener {
+            val navController = Navigation.findNavController(requireActivity(), R.id.garden_nav_fragment)
+            navController.navigateUp()
+        } }
 
         return binding.root
     }

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2018 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_garden.xml
+++ b/app/src/main/res/layout/activity_garden.xml
@@ -25,7 +25,7 @@
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">
 
-        <LinearLayout
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical">
@@ -52,7 +52,7 @@
                 app:defaultNavHost="true"
                 app:navGraph="@navigation/nav_garden"/>
 
-        </LinearLayout>
+        </FrameLayout>
 
         <android.support.design.widget.NavigationView
             android:id="@+id/navigation_view"

--- a/app/src/main/res/layout/fragment_garden.xml
+++ b/app/src/main/res/layout/fragment_garden.xml
@@ -16,10 +16,11 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+             xmlns:app="http://schemas.android.com/apk/res-auto"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             android:paddingTop="?attr/actionBarSize">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/garden_list"
@@ -29,7 +30,7 @@
         android:paddingLeft="@dimen/margin_normal"
         android:paddingRight="@dimen/margin_normal"
         app:layoutManager="android.support.v7.widget.LinearLayoutManager"
-        tools:listitem="@layout/list_item_garden_planting" />
+        tools:listitem="@layout/list_item_garden_planting"/>
 
     <TextView
         android:id="@+id/empty_garden"
@@ -37,6 +38,6 @@
         android:layout_height="match_parent"
         android:gravity="center"
         android:text="@string/garden_empty"
-        android:textSize="24sp" />
+        android:textSize="24sp"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_plant_detail.xml
+++ b/app/src/main/res/layout/fragment_plant_detail.xml
@@ -61,6 +61,7 @@
                 <android.support.v7.widget.Toolbar
                     android:id="@+id/detail_toolbar"
                     android:layout_width="match_parent"
+                    app:navigationIcon="@drawable/ic_arrow_back"
                     android:layout_height="?attr/actionBarSize"
                     app:layout_collapseMode="pin"
                     app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />

--- a/app/src/main/res/layout/fragment_plant_list.xml
+++ b/app/src/main/res/layout/fragment_plant_list.xml
@@ -15,17 +15,19 @@
   ~ limitations under the License.
   -->
 
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools">
 
-    <android.support.v7.widget.RecyclerView xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
+    <android.support.v7.widget.RecyclerView
         android:id="@+id/plant_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:paddingLeft="@dimen/margin_normal"
         android:paddingRight="@dimen/margin_normal"
+        android:paddingTop="?attr/actionBarSize"
         app:layoutManager="android.support.v7.widget.LinearLayoutManager"
         tools:context="com.google.samples.apps.sunflower.GardenActivity"
-        tools:listitem="@layout/list_item_plant" />
+        tools:listitem="@layout/list_item_plant"/>
 </layout>


### PR DESCRIPTION
- This PR would fix the bug that the detail page shows two appbars which one of them come from main and another from detail itself. 
- The approach is still using appbar of detail but using a "back" icon for navi-up of navi-controller. 
- A fade-in/out effect has been used while opening item from main to detail.