### PR TITLE
Fix, ignore ktlint in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 .externalNativeBuild
+ktlint


### PR DESCRIPTION
Some people would push a massive large file if it is not ignored.