### PR TITLE
issue#111 Extract plant click listener logic from Adapter to Fragment

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -26,6 +26,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.findNavController
 import com.google.samples.apps.sunflower.adapters.PlantAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentPlantListBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
@@ -46,7 +47,11 @@ class PlantListFragment : Fragment() {
         val factory = InjectorUtils.providePlantListViewModelFactory(context)
         viewModel = ViewModelProviders.of(this, factory).get(PlantListViewModel::class.java)
 
-        val adapter = PlantAdapter()
+        val plantClickListener: (String) -> Unit = {
+            val direction = PlantListFragmentDirections.ActionPlantListFragmentToPlantDetailFragment(it)
+            binding.root.findNavController().navigate(direction)
+        }
+        val adapter = PlantAdapter(plantClickListener)
         binding.plantList.adapter = adapter
         subscribeUi(adapter)
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -19,11 +19,9 @@ package com.google.samples.apps.sunflower.adapters
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.findNavController
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.samples.apps.sunflower.PlantListFragment
-import com.google.samples.apps.sunflower.PlantListFragmentDirections
 import com.google.samples.apps.sunflower.data.Plant
 import com.google.samples.apps.sunflower.databinding.ListItemPlantBinding
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -30,12 +30,16 @@ import com.google.samples.apps.sunflower.databinding.ListItemPlantBinding
 /**
  * Adapter for the [RecyclerView] in [PlantListFragment].
  */
-class PlantAdapter : ListAdapter<Plant, PlantAdapter.ViewHolder>(PlantDiffCallback()) {
+class PlantAdapter(
+    private val plantClickListener: (String) -> Unit
+) : ListAdapter<Plant, PlantAdapter.ViewHolder>(PlantDiffCallback()) {
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val plant = getItem(position)
         holder.apply {
-            bind(createOnClickListener(plant.plantId), plant)
+            bind(View.OnClickListener {
+                plantClickListener(plant.plantId)
+            }, plant)
             itemView.tag = plant
         }
     }
@@ -43,13 +47,6 @@ class PlantAdapter : ListAdapter<Plant, PlantAdapter.ViewHolder>(PlantDiffCallba
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(ListItemPlantBinding.inflate(
                 LayoutInflater.from(parent.context), parent, false))
-    }
-
-    private fun createOnClickListener(plantId: String): View.OnClickListener {
-        return View.OnClickListener {
-            val direction = PlantListFragmentDirections.ActionPlantListFragmentToPlantDetailFragment(plantId)
-            it.findNavController().navigate(direction)
-        }
     }
 
     class ViewHolder(


### PR DESCRIPTION
As explained on issue 111, the logic of the plant item click listener was implemented on *PlantAdapter*. The new changes are about extracting this logic from the *PlantAdapter* to *PlantListFragment*. Instead of creating an interface and passing it to adapter for using it as callback, the approach implemented make use of a lambda function.