### PR TITLE
Update ktlint Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ from the ktlint [README](https://github.com/shyiko/ktlint/blob/master/README.md)
 
 - Download ktlint:
 
-  `curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint`
+  `curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/`
+
+  On macOS (or [Linux](http://linuxbrew.sh/)) you can also use [brew](https://brew.sh/) - `brew install shyiko/ktlint/ktlint`
 
 - Inside the project root directory run:
 

--- a/README.md
+++ b/README.md
@@ -100,19 +100,11 @@ from the ktlint [README](https://github.com/shyiko/ktlint/blob/master/README.md)
 
 - Close Android Studio if it's open
 
-- Download ktlint:
-
-  `curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/`
-
-  On macOS (or [Linux](http://linuxbrew.sh/)) you can also use [brew](https://brew.sh/) - `brew install shyiko/ktlint/ktlint`
+- Download ktlint using these [installation instructions](https://github.com/shyiko/ktlint/blob/master/README.md#installation).
 
 - Inside the project root directory run:
 
   `ktlint --apply-to-idea-project --android`
-
-- Remove ktlint if desired:
-
-  `rm ktlint`
 
 - Start Android Studio
 


### PR DESCRIPTION
This pull request updates the ktlint installation instructions to match the [README](https://github.com/shyiko/ktlint/blob/master/README.md) of [ktlint](https://github.com/shyiko/ktlint). 

Specifically, we add `&& sudo mv ktlint /home/local/bin` to  `curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint`

Since ktlint was not in my `/home/local/bin` directory, on my setup of macOS using ZSH, I was unable to run `ktlint --apply-to-idea-project --android`

This PR adds installation instructions to avoid: `zsh: command not found: ktlint`

It also adds a blurb about installing via homebrew (also found from ktlint readme) which will by default put ktlint into `/home/local/bin`