### PR TITLE
Change "plant" to be non-optional.

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/data/PlantAndGardenPlantings.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/PlantAndGardenPlantings.kt
@@ -26,7 +26,7 @@ import androidx.room.Relation
 class PlantAndGardenPlantings {
 
     @Embedded
-    var plant: Plant? = null
+    lateinit var plant: Plant
 
     @Relation(parentColumn = "id", entityColumn = "plant_id")
     var gardenPlantings: List<GardenPlanting> = arrayListOf()

--- a/app/src/test/java/com/google/samples/apps/sunflower/data/PlantAndGardenPlantingTest.kt
+++ b/app/src/test/java/com/google/samples/apps/sunflower/data/PlantAndGardenPlantingTest.kt
@@ -16,7 +16,6 @@
 
 package com.google.samples.apps.sunflower.data
 
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -24,7 +23,6 @@ class PlantAndGardenPlantingTest {
 
     @Test fun test_default_values() {
         val p = PlantAndGardenPlantings()
-        assertNull(p.plant)
         assertTrue(p.gardenPlantings.isEmpty())
     }
 }


### PR DESCRIPTION
Tiny change to PlantAndGardenPlantings to make the `plant` member
lateinit and non-optional (`Plant` vs `Plant?`).