### PR TITLE
remove unnecessary safe call from GardenPlantDiffCallback

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantDiffCallback.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantDiffCallback.kt
@@ -25,7 +25,7 @@ class GardenPlantDiffCallback : DiffUtil.ItemCallback<PlantAndGardenPlantings>()
         oldItem: PlantAndGardenPlantings,
         newItem: PlantAndGardenPlantings
     ): Boolean {
-        return oldItem.plant?.plantId == newItem.plant?.plantId
+        return oldItem.plant.plantId == newItem.plant.plantId
     }
 
     override fun areContentsTheSame(


### PR DESCRIPTION
Hi!
i remove unnecessary safe call. cuz output warning logs.

```
GardenPlantDiffCallback.kt: (28, 29): Unnecessary safe call on a non-null receiver of type Plant
GardenPlantDiffCallback.kt: (28, 55): Unnecessary safe call on a non-null receiver of type Plant
```
