### PR TITLE
[WIP] Add explicit dependency on Fragment 1.1.0 alpha

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,4 +72,8 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-intents:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:$rootProject.uiAutomatorVersion"
     testImplementation "junit:junit:$rootProject.junitVersion"
+
+    // Explicitly add dependency for Fragment due to
+    // https://github.com/googlesamples/android-sunflower/issues/239
+    implementation "androidx.fragment:fragment:1.1.0-alpha02"
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -76,14 +76,14 @@ class PlantDetailFragment : Fragment() {
         return binding.root
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
-        inflater?.inflate(R.menu.menu_plant_detail, menu)
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.menu_plant_detail, menu)
         super.onCreateOptionsMenu(menu, inflater)
     }
 
     @Suppress("DEPRECATION")
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        return when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
             R.id.action_share -> {
                 val shareIntent = ShareCompat.IntentBuilder.from(activity)
                     .setText(shareText)

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -54,8 +54,8 @@ class PlantListFragment : Fragment() {
         return binding.root
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
-        inflater?.inflate(R.menu.menu_plant_list, menu)
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.menu_plant_list, menu)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
This is to fix https://github.com/googlesamples/android-sunflower/issues/239, where tapping on two list items will cause a crash.

This also updates the Fragment overrides to match the params.