### PR TITLE
use primitive type in databinding variable, not boxed type

### DIFF
--- a/app/src/main/res/layout/fragment_garden.xml
+++ b/app/src/main/res/layout/fragment_garden.xml
@@ -23,7 +23,7 @@
 
         <variable
                 name="hasPlantings"
-                type="Boolean" />
+                type="boolean" />
 
     </data>
 


### PR DESCRIPTION
The warning log below is output now. 

```
w: warning: !hasPlantings is a boxed field but needs to be un-boxed to execute app:isGone. 
This may cause NPE so Data Binding will safely unbox it. 
You can change the expression and explicitly wrap !hasPlantings with safeUnbox() to prevent the warning
```

This field does not become null. I think that the primitive type is better.
