### PR TITLE
Omit .applicationContext in SeedDatabaseWorker

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
@@ -30,7 +30,7 @@ import com.google.samples.apps.sunflower.utilities.PLANT_DATA_FILENAME
 class SeedDatabaseWorker(
     context: Context,
     workerParams: WorkerParameters
-) : Worker(context.applicationContext, workerParams) {
+) : Worker(context, workerParams) {
 
     private val TAG by lazy { SeedDatabaseWorker::class.java.simpleName }
 


### PR DESCRIPTION
Per https://issuetracker.google.com/issues/123014564, this isn't necessary.