### PR TITLE
[UPDATE] Material Design Lib 1.1.0-alpha02

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         ktlintVersion = '0.29.0'
         ktxVersion = '1.0.1'
         lifecycleVersion = '2.0.0'
-        materialVersion = '1.0.0'
+        materialVersion = '1.1.0-alpha02'
         navigationVersion = '1.0.0-alpha11'
         recyclerViewVersion = '1.0.0'
         roomVersion = '2.1.0-alpha04'


### PR DESCRIPTION
Update the material design library to `1.1.0-alpha02` for the reasons:

`MD-Lib + Theme.MaterialComponents.DayNight.NoActionBar` .
One of preparations for #278
