### PR TITLE
Reduced animation time between fragment transitions

### DIFF
--- a/app/src/main/res/anim/slide_in_right.xml
+++ b/app/src/main/res/anim/slide_in_right.xml
@@ -18,5 +18,5 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <translate android:fromXDelta="100%" android:toXDelta="0%"
         android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="700"/>
+        android:duration="@integer/slide"/>
 </set>

--- a/app/src/main/res/anim/slide_out_left.xml
+++ b/app/src/main/res/anim/slide_out_left.xml
@@ -18,5 +18,5 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <translate android:fromXDelta="0%" android:toXDelta="-100%"
         android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="700"/>
+        android:duration="@integer/slide"/>
 </set>

--- a/app/src/main/res/anim/slide_out_right.xml
+++ b/app/src/main/res/anim/slide_out_right.xml
@@ -18,5 +18,5 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android">
     <translate android:fromXDelta="0%" android:toXDelta="100%"
         android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="700"/>
+        android:duration="@integer/slide"/>
 </set>

--- a/app/src/main/res/values/anim.xml
+++ b/app/src/main/res/values/anim.xml
@@ -19,5 +19,5 @@
 <resources>
 
     <!-- Duration (in milliseconds) for slide transition animation -->
-    <integer name="slide">700</integer>
+    <integer name="slide">400</integer>
 </resources>

--- a/app/src/main/res/values/anim.xml
+++ b/app/src/main/res/values/anim.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2018 Google LLC
+  ~ Copyright 2019 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
   ~ limitations under the License.
   -->
 
-<set xmlns:android="http://schemas.android.com/apk/res/android">
-    <translate android:fromXDelta="-100%" android:toXDelta="0%"
-        android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="@integer/slide"/>
-</set>
+<!-- Values used for animations -->
+<resources>
+
+    <!-- Duration (in milliseconds) for slide transition animation -->
+    <integer name="slide">700</integer>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         // App dependencies
         constraintLayoutVersion = '2.0.0-alpha3'
         coreTestingVersion = '2.0.0'
-        coroutinesVersion = "1.0.1"
+        coroutinesVersion = "1.1.1"
         espressoVersion = '3.1.0-alpha4'
         glideVersion = '4.8.0'
         gradleVersion = '3.3.1'


### PR DESCRIPTION
Implemented a fix for issue #265. The reduced animation time provides a seamless transition between fragments.