### PR TITLE
[OPTIMIZE] Change plantId of class Plant to long

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/data/PlantDaoTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/data/PlantDaoTest.kt
@@ -33,9 +33,9 @@ import org.junit.runner.RunWith
 class PlantDaoTest {
     private lateinit var database: AppDatabase
     private lateinit var plantDao: PlantDao
-    private val plantA = Plant("1", "A", "", 1, 1, "")
-    private val plantB = Plant("2", "B", "", 1, 1, "")
-    private val plantC = Plant("3", "C", "", 2, 2, "")
+    private val plantA = Plant(1, "A", "", 1, 1, "")
+    private val plantB = Plant(2, "B", "", 1, 1, "")
+    private val plantC = Plant(3, "C", "", 2, 2, "")
 
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/utilities/TestUtils.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/utilities/TestUtils.kt
@@ -32,9 +32,9 @@ import java.util.Calendar
  * [Plant] objects used for tests.
  */
 val testPlants = arrayListOf(
-    Plant("1", "Apple", "A red fruit", 1),
-    Plant("2", "B", "Description B", 1),
-    Plant("3", "C", "Description C", 2)
+    Plant(1, "Apple", "A red fruit", 1),
+    Plant(2, "B", "Description B", 1),
+    Plant(3, "C", "Description C", 2)
 )
 val testPlant = testPlants[0]
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/GardenPlantingAdapter.kt
@@ -51,7 +51,7 @@ class GardenPlantingAdapter :
         }
     }
 
-    private fun createOnClickListener(plantId: String): View.OnClickListener {
+    private fun createOnClickListener(plantId: Long): View.OnClickListener {
         return View.OnClickListener {
                 val direction =
                         GardenFragmentDirections.actionGardenFragmentToPlantDetailFragment(plantId)

--- a/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/adapters/PlantAdapter.kt
@@ -46,7 +46,7 @@ class PlantAdapter : ListAdapter<Plant, PlantAdapter.ViewHolder>(PlantDiffCallba
                 LayoutInflater.from(parent.context), parent, false))
     }
 
-    private fun createOnClickListener(plantId: String): View.OnClickListener {
+    private fun createOnClickListener(plantId: Long): View.OnClickListener {
         return View.OnClickListener {
             val direction = PlantListFragmentDirections.actionPlantListFragmentToPlantDetailFragment(plantId)
             it.findNavController().navigate(direction)

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlanting.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlanting.kt
@@ -37,7 +37,7 @@ import java.util.Calendar
     indices = [Index("plant_id")]
 )
 data class GardenPlanting(
-    @ColumnInfo(name = "plant_id") val plantId: String,
+    @ColumnInfo(name = "plant_id") val plantId: Long,
 
     /**
      * Indicates when the [Plant] was planted. Used for showing notification when it's time

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingDao.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingDao.kt
@@ -35,7 +35,7 @@ interface GardenPlantingDao {
     fun getGardenPlanting(gardenPlantingId: Long): LiveData<GardenPlanting>
 
     @Query("SELECT * FROM garden_plantings WHERE plant_id = :plantId")
-    fun getGardenPlantingForPlant(plantId: String): LiveData<GardenPlanting>
+    fun getGardenPlantingForPlant(plantId: Long): LiveData<GardenPlanting>
 
     /**
      * This query will tell Room to query both the [Plant] and [GardenPlanting] tables and handle

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingRepository.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingRepository.kt
@@ -23,7 +23,7 @@ class GardenPlantingRepository private constructor(
     private val gardenPlantingDao: GardenPlantingDao
 ) {
 
-    suspend fun createGardenPlanting(plantId: String) {
+    suspend fun createGardenPlanting(plantId: Long) {
         withContext(IO) {
             val gardenPlanting = GardenPlanting(plantId)
             gardenPlantingDao.insertGardenPlanting(gardenPlanting)
@@ -36,7 +36,7 @@ class GardenPlantingRepository private constructor(
         }
     }
 
-    fun getGardenPlantingForPlant(plantId: String) =
+    fun getGardenPlantingForPlant(plantId: Long) =
             gardenPlantingDao.getGardenPlantingForPlant(plantId)
 
     fun getGardenPlantings() = gardenPlantingDao.getGardenPlantings()

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/Plant.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/Plant.kt
@@ -24,7 +24,7 @@ import java.util.Calendar.DAY_OF_YEAR
 
 @Entity(tableName = "plants")
 data class Plant(
-    @PrimaryKey @ColumnInfo(name = "id") val plantId: String,
+    @PrimaryKey @ColumnInfo(name = "id") val plantId: Long,
     val name: String,
     val description: String,
     val growZoneNumber: Int,

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/PlantDao.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/PlantDao.kt
@@ -34,7 +34,7 @@ interface PlantDao {
     fun getPlantsWithGrowZoneNumber(growZoneNumber: Int): LiveData<List<Plant>>
 
     @Query("SELECT * FROM plants WHERE id = :plantId")
-    fun getPlant(plantId: String): LiveData<Plant>
+    fun getPlant(plantId: Long): LiveData<Plant>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(plants: List<Plant>)

--- a/app/src/main/java/com/google/samples/apps/sunflower/data/PlantRepository.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/PlantRepository.kt
@@ -23,7 +23,7 @@ class PlantRepository private constructor(private val plantDao: PlantDao) {
 
     fun getPlants() = plantDao.getPlants()
 
-    fun getPlant(plantId: String) = plantDao.getPlant(plantId)
+    fun getPlant(plantId: Long) = plantDao.getPlant(plantId)
 
     fun getPlantsWithGrowZoneNumber(growZoneNumber: Int) =
             plantDao.getPlantsWithGrowZoneNumber(growZoneNumber)

--- a/app/src/main/java/com/google/samples/apps/sunflower/utilities/InjectorUtils.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/utilities/InjectorUtils.kt
@@ -53,7 +53,7 @@ object InjectorUtils {
 
     fun providePlantDetailViewModelFactory(
         context: Context,
-        plantId: String
+        plantId: Long
     ): PlantDetailViewModelFactory {
         return PlantDetailViewModelFactory(getPlantRepository(context),
                 getGardenPlantingRepository(context), plantId)

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModel.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.launch
 class PlantDetailViewModel(
     plantRepository: PlantRepository,
     private val gardenPlantingRepository: GardenPlantingRepository,
-    private val plantId: String
+    private val plantId: Long
 ) : ViewModel() {
 
     val isPlanted: LiveData<Boolean>

--- a/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelFactory.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelFactory.kt
@@ -30,7 +30,7 @@ import com.google.samples.apps.sunflower.data.PlantRepository
 class PlantDetailViewModelFactory(
     private val plantRepository: PlantRepository,
     private val gardenPlantingRepository: GardenPlantingRepository,
-    private val plantId: String
+    private val plantId: Long
 ) : ViewModelProvider.NewInstanceFactory() {
 
     @Suppress("UNCHECKED_CAST")

--- a/app/src/main/res/navigation/nav_garden.xml
+++ b/app/src/main/res/navigation/nav_garden.xml
@@ -57,7 +57,7 @@
         tools:layout="@layout/fragment_plant_detail">
         <argument
             android:name="plantId"
-            app:argType="string" />
+            app:argType="long" />
     </fragment>
 
 </navigation>

--- a/app/src/test/java/com/google/samples/apps/sunflower/data/GardenPlantingTest.kt
+++ b/app/src/test/java/com/google/samples/apps/sunflower/data/GardenPlantingTest.kt
@@ -29,7 +29,7 @@ class GardenPlantingTest {
 
     @Test
     fun testDefaultValues() {
-        val gardenPlanting = GardenPlanting("1")
+        val gardenPlanting = GardenPlanting(1)
         val cal = Calendar.getInstance()
         assertYMD(cal, gardenPlanting.plantDate)
         assertYMD(cal, gardenPlanting.lastWateringDate)

--- a/app/src/test/java/com/google/samples/apps/sunflower/data/PlantTest.kt
+++ b/app/src/test/java/com/google/samples/apps/sunflower/data/PlantTest.kt
@@ -29,11 +29,11 @@ class PlantTest {
     private lateinit var plant: Plant
 
     @Before fun setUp() {
-        plant = Plant("1", "Tomato", "A red vegetable", 1, 2, "")
+        plant = Plant(1, "Tomato", "A red vegetable", 1, 2, "")
     }
 
     @Test fun test_default_values() {
-        val defaultPlant = Plant("2", "Apple", "Description", 1)
+        val defaultPlant = Plant(2, "Apple", "Description", 1)
         assertEquals(7, defaultPlant.wateringInterval)
         assertEquals("", defaultPlant.imageUrl)
     }


### PR DESCRIPTION
I think this was a bug that the `Plant`  has the `plantId: String`  but in the `GardenPlanting` which associates with `Plant` is using `foreignKeys` : `plantId: Long`

The commit has only changed `plantId: String` to `plantId: Long`, nothing else.

@tiembo @nic0lette 