### PR TITLE
[SECURITY] Use HTTPS to download dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url 'http://dl.bintray.com/kotlin/kotlin-eap' }
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
@@ -66,7 +66,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'http://dl.bintray.com/kotlin/kotlin-eap' }
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 }
 


### PR DESCRIPTION
[CWE-829: Inclusion of Functionality from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html)
[CWE-494: Download of Code Without Integrity Check](https://cwe.mitre.org/data/definitions/494.html)

The build files indicate that this project is resolving dependencies over HTTP instead of HTTPS. Any of these artifacts could have been MITM to maliciously compromise them and infect the build artifacts that were produced. Additionally, if any of these JARs or other dependencies were compromised, any developers using these could continue to be infected past updating to fix this.

This vulnerability has a CVSS v3.0 Base Score of 8.1/10
https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H

### This isn't just theoretical
POC code has existed since 2014 to maliciously compromise a JAR file inflight.
See:
* https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/
* https://github.com/mveytsman/dilettante

### MITM Attacks Increasingly Common
See:
* https://serverfault.com/a/153065
* https://security.stackexchange.com/a/12050
