### PR TITLE
Removing Kotlin EAP Maven entries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
@@ -66,7 +65,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 }
 


### PR DESCRIPTION
Sunflower is now using stable Kotlin resources.