### PR TITLE
Use ArchTaskExecutor instead of InstantTaskExecutorRule

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/data/GardenPlantingDaoTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/data/GardenPlantingDaoTest.kt
@@ -16,29 +16,26 @@
 
 package com.google.samples.apps.sunflower.data
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import com.google.samples.apps.sunflower.utilities.getValue
+import com.google.samples.apps.sunflower.utilities.registerTaskExecutor
 import com.google.samples.apps.sunflower.utilities.testCalendar
 import com.google.samples.apps.sunflower.utilities.testGardenPlanting
 import com.google.samples.apps.sunflower.utilities.testPlant
 import com.google.samples.apps.sunflower.utilities.testPlants
+import com.google.samples.apps.sunflower.utilities.unRegisterTaskExecutor
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.After
 import org.junit.Assert.assertNull
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
 class GardenPlantingDaoTest {
     private lateinit var database: AppDatabase
     private lateinit var gardenPlantingDao: GardenPlantingDao
     private var testGardenPlantingId: Long = 0
-
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @Before fun createDb() {
         val context = InstrumentationRegistry.getTargetContext()
@@ -47,10 +44,14 @@ class GardenPlantingDaoTest {
 
         database.plantDao().insertAll(testPlants)
         testGardenPlantingId = gardenPlantingDao.insertGardenPlanting(testGardenPlanting)
+
+        registerTaskExecutor()
     }
 
     @After fun closeDb() {
         database.close()
+
+        unRegisterTaskExecutor()
     }
 
     @Test fun testGetGardenPlantings() {

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/data/PlantDaoTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/data/PlantDaoTest.kt
@@ -16,16 +16,16 @@
 
 package com.google.samples.apps.sunflower.data
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
 import com.google.samples.apps.sunflower.utilities.getValue
+import com.google.samples.apps.sunflower.utilities.registerTaskExecutor
+import com.google.samples.apps.sunflower.utilities.unRegisterTaskExecutor
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Assert.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -37,9 +37,6 @@ class PlantDaoTest {
     private val plantB = Plant("2", "B", "", 1, 1, "")
     private val plantC = Plant("3", "C", "", 2, 2, "")
 
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
-
     @Before fun createDb() {
         val context = InstrumentationRegistry.getTargetContext()
         database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
@@ -47,10 +44,14 @@ class PlantDaoTest {
 
         // Insert plants in non-alphabetical order to test that results are sorted by name
         plantDao.insertAll(listOf(plantB, plantC, plantA))
+
+        registerTaskExecutor()
     }
 
     @After fun closeDb() {
         database.close()
+
+        unRegisterTaskExecutor()
     }
 
     @Test fun testGetPlants() {

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/utilities/TaskExecutorUtils.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/utilities/TaskExecutorUtils.kt
@@ -1,0 +1,30 @@
+package com.google.samples.apps.sunflower.utilities
+
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+
+/**
+ * Helper methods for serves as a central point to execute common tasks, from
+ * https://android.googlesource.com/platform/frameworks/support/+/refs/tags/android-p-preview-1/app-toolkit/runtime/src/main/java/android/arch/core/executor/ArchTaskExecutor.java
+ *
+ * Sets a delegate to handle task execution requests using TaskExecutor as the delegate.
+ * App Toolkit components will use a TaskExecutors.
+ */
+fun registerTaskExecutor() {
+    ArchTaskExecutor.getInstance().setDelegate(object : TaskExecutor() {
+        override fun executeOnDiskIO(runnable: Runnable) = runnable.run()
+        override fun isMainThread() = true
+        override fun postToMainThread(runnable: Runnable) = runnable.run()
+    })
+}
+
+/**
+ * Helper methods for serves as a central point to execute common tasks, from
+ * https://android.googlesource.com/platform/frameworks/support/+/refs/tags/android-p-preview-1/app-toolkit/runtime/src/main/java/android/arch/core/executor/ArchTaskExecutor.java
+ *
+ * Sets the default delegate to handle task execution requests.
+ * App Toolkit components will use the default TaskExecutor.
+ */
+fun unRegisterTaskExecutor() {
+    ArchTaskExecutor.getInstance().setDelegate(null)
+}

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/viewmodels/PlantDetailViewModelTest.kt
@@ -16,27 +16,24 @@
 
 package com.google.samples.apps.sunflower.viewmodels
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.InstrumentationRegistry
 import com.google.samples.apps.sunflower.data.AppDatabase
 import com.google.samples.apps.sunflower.data.GardenPlantingRepository
 import com.google.samples.apps.sunflower.data.PlantRepository
 import com.google.samples.apps.sunflower.utilities.getValue
+import com.google.samples.apps.sunflower.utilities.registerTaskExecutor
 import com.google.samples.apps.sunflower.utilities.testPlant
+import com.google.samples.apps.sunflower.utilities.unRegisterTaskExecutor
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
 class PlantDetailViewModelTest {
 
     private lateinit var appDatabase: AppDatabase
     private lateinit var viewModel: PlantDetailViewModel
-
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @Before
     fun setUp() {
@@ -47,11 +44,15 @@ class PlantDetailViewModelTest {
         val gardenPlantingRepo = GardenPlantingRepository.getInstance(
                 appDatabase.gardenPlantingDao())
         viewModel = PlantDetailViewModel(plantRepo, gardenPlantingRepo, testPlant.plantId)
+
+        registerTaskExecutor()
     }
 
     @After
     fun tearDown() {
         appDatabase.close()
+
+        unRegisterTaskExecutor()
     }
 
     @Test


### PR DESCRIPTION
### Use ArchTaskExecutor instead of InstantTaskExecutorRule

```kotlin
@get:Rule
var instantTaskExecutorRule = InstantTaskExecutorRule()
```

The issue is that this one does not provide a real thread for main thread and accepts all threads as main; hence might hide some bugs by having a different behavior than the real implementation. (and it is likely to be deprecated - removed). by __yigit__.

#### Modified:
- removed InstantTaskExecutorRule
- added TaskExecutorUtils : registerTaskExecutor(), unRegisterTaskExecutor()