### PR TITLE
Remove deprecated coroutineContext override.

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
@@ -26,7 +26,6 @@ import com.google.gson.stream.JsonReader
 import com.google.samples.apps.sunflower.data.AppDatabase
 import com.google.samples.apps.sunflower.data.Plant
 import com.google.samples.apps.sunflower.utilities.PLANT_DATA_FILENAME
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 
 class SeedDatabaseWorker(
@@ -35,7 +34,6 @@ class SeedDatabaseWorker(
 ) : CoroutineWorker(context, workerParams) {
 
     private val TAG by lazy { SeedDatabaseWorker::class.java.simpleName }
-    override val coroutineContext = Dispatchers.IO
 
     override suspend fun doWork(): Result = coroutineScope {
 


### PR DESCRIPTION
WorkManager v2.1 has deprecated coroutineContext. If you need to have
your CoroutineWorker run on a different Dispatcher, you can go to the
desired coroutineContext yourself in the body of the suspending
function.