### PR TITLE
Add WorkManager test for SeedDatabaseWorker

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,5 +72,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-intents:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:$rootProject.uiAutomatorVersion"
+    androidTestImplementation "androidx.work:work-testing:$rootProject.workVersion"
+    androidTestImplementation "com.google.truth:truth:$rootProject.truth"
     testImplementation "junit:junit:$rootProject.junitVersion"
 }

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.worker
+
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker.Result
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.google.samples.apps.sunflower.workers.SeedDatabaseWorker
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class RefreshMainDataWorkTest {
+    private lateinit var context: Context
+    private lateinit var workManager: WorkManager
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        workManager = WorkManager.getInstance(context)
+    }
+
+    @Test
+    fun testRefreshMainDataWork() {
+        // Create request
+        val request = OneTimeWorkRequestBuilder<SeedDatabaseWorker>()
+                .build()
+
+        // Get the ListenableWorker
+        val worker = TestListenableWorkerBuilder.from(context, request).build()
+
+        // Start the work synchronously
+        val result = worker.startWork().get()
+
+        assertThat(result, `is` (Result.success()))
+    }
+}

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
@@ -16,7 +16,6 @@
 
 package com.google.samples.apps.sunflower.worker
 
-
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker.Result
@@ -49,6 +48,6 @@ class RefreshMainDataWorkTest {
         // Start the work synchronously
         val result = worker.startWork().get()
 
-        assertThat(result, `is` (Result.success()))
+        assertThat(result, `is`(Result.success()))
     }
 }

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
@@ -20,7 +20,6 @@ package com.google.samples.apps.sunflower.worker
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker.Result
-import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.google.samples.apps.sunflower.workers.SeedDatabaseWorker
@@ -44,12 +43,8 @@ class RefreshMainDataWorkTest {
 
     @Test
     fun testRefreshMainDataWork() {
-        // Create request
-        val request = OneTimeWorkRequestBuilder<SeedDatabaseWorker>()
-                .build()
-
         // Get the ListenableWorker
-        val worker = TestListenableWorkerBuilder.from(context, request).build()
+        val worker = TestListenableWorkerBuilder<SeedDatabaseWorker>(context).build()
 
         // Start the work synchronously
         val result = worker.startWork().get()

--- a/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/workers/SeedDatabaseWorker.kt
@@ -26,7 +26,6 @@ import com.google.gson.stream.JsonReader
 import com.google.samples.apps.sunflower.data.AppDatabase
 import com.google.samples.apps.sunflower.data.Plant
 import com.google.samples.apps.sunflower.utilities.PLANT_DATA_FILENAME
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 
 class SeedDatabaseWorker(

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         constraintLayoutVersion = '2.0.0-alpha4'
         coreTestingVersion = '2.0.0'
         coroutinesVersion = "1.1.1"
-        espressoVersion = '3.1.0-alpha4'
+        espressoVersion = '3.1.1'
         glideVersion = '4.9.0'
         gradleVersion = '3.4.0'
         gsonVersion = '2.8.2'
@@ -41,6 +41,7 @@ buildscript {
         roomVersion = '2.1.0-alpha06'
         runnerVersion = '1.0.1'
         supportLibraryVersion = '1.1.0-alpha04'
+        truth = '0.42'
         uiAutomatorVersion = '2.2.0'
         workVersion = '2.1.0-alpha01'
     }


### PR DESCRIPTION
This add a test for the `SeedDatabaseWorker` using the `TestListenableWorkerBuilder` introduced in WorkManager v2.1.