### PR TITLE
[FIX] Warning on call deprecated WorkManager.getInstance()

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/data/AppDatabase.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/AppDatabase.kt
@@ -55,7 +55,7 @@ abstract class AppDatabase : RoomDatabase() {
                         override fun onCreate(db: SupportSQLiteDatabase) {
                             super.onCreate(db)
                             val request = OneTimeWorkRequestBuilder<SeedDatabaseWorker>().build()
-                            WorkManager.getInstance().enqueue(request)
+                            WorkManager.getInstance(context).enqueue(request)
                         }
                     })
                     .build()


### PR DESCRIPTION
Call `WorkManager.getInstance(context)` instead.