### PR TITLE
Initialize the ViewModel using the extension function

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$rootProject.supportLibraryVersion"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.constraintLayoutVersion"
     implementation "androidx.core:core-ktx:$rootProject.ktxVersion"
+    implementation "androidx.fragment:fragment-ktx:$rootProject.fragmentVersion"
     implementation "androidx.lifecycle:lifecycle-extensions:$rootProject.lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$rootProject.lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$rootProject.lifecycleVersion"

--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -21,14 +21,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import com.google.samples.apps.sunflower.adapters.GardenPlantingAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentGardenBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
 import com.google.samples.apps.sunflower.viewmodels.GardenPlantingListViewModel
 
 class GardenFragment : Fragment() {
+
+    private val viewModel: GardenPlantingListViewModel by viewModels {
+        InjectorUtils.provideGardenPlantingListViewModelFactory(requireContext())
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -43,10 +47,6 @@ class GardenFragment : Fragment() {
     }
 
     private fun subscribeUi(adapter: GardenPlantingAdapter, binding: FragmentGardenBinding) {
-        val factory = InjectorUtils.provideGardenPlantingListViewModelFactory(requireContext())
-        val viewModel = ViewModelProviders.of(this, factory)
-                .get(GardenPlantingListViewModel::class.java)
-
         viewModel.gardenPlantings.observe(viewLifecycleOwner, Observer { plantings ->
             binding.hasPlantings = !plantings.isNullOrEmpty()
         })

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -28,8 +28,8 @@ import android.view.ViewGroup
 import androidx.core.app.ShareCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
 import com.google.samples.apps.sunflower.databinding.FragmentPlantDetailBinding
@@ -44,15 +44,15 @@ class PlantDetailFragment : Fragment() {
     private val args: PlantDetailFragmentArgs by navArgs()
     private lateinit var shareText: String
 
+    private val plantDetailViewModel: PlantDetailViewModel by viewModels {
+        InjectorUtils.providePlantDetailViewModelFactory(requireActivity(), args.plantId)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val factory = InjectorUtils.providePlantDetailViewModelFactory(requireActivity(), args.plantId)
-        val plantDetailViewModel = ViewModelProviders.of(this, factory)
-                .get(PlantDetailViewModel::class.java)
-
         val binding = DataBindingUtil.inflate<FragmentPlantDetailBinding>(
                 inflater, R.layout.fragment_plant_detail, container, false).apply {
             viewModel = plantDetailViewModel

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -24,8 +24,8 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import com.google.samples.apps.sunflower.adapters.PlantAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentPlantListBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
@@ -33,7 +33,9 @@ import com.google.samples.apps.sunflower.viewmodels.PlantListViewModel
 
 class PlantListFragment : Fragment() {
 
-    private lateinit var viewModel: PlantListViewModel
+    private val viewModel: PlantListViewModel by viewModels {
+        InjectorUtils.providePlantListViewModelFactory(requireContext())
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -41,10 +43,7 @@ class PlantListFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val binding = FragmentPlantListBinding.inflate(inflater, container, false)
-        val context = context ?: return binding.root
-
-        val factory = InjectorUtils.providePlantListViewModelFactory(context)
-        viewModel = ViewModelProviders.of(this, factory).get(PlantListViewModel::class.java)
+        context ?: return binding.root
 
         val adapter = PlantAdapter()
         binding.plantList.adapter = adapter

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
         coreTestingVersion = '2.0.0'
         coroutinesVersion = "1.1.1"
         espressoVersion = '3.1.1'
+        fragmentVersion = '1.1.0-alpha08'
         glideVersion = '4.9.0'
         gradleVersion = '3.4.0'
         gsonVersion = '2.8.2'


### PR DESCRIPTION
I replaced `ViewModelProviders.of(lifecycleOwner, factory).get(class)` with the `vimeModels` extension in `fragment-ktx`, which seems to be more in line with the `Kotlin` syntax, like this:

**From** 

```kotlin
val factory = InjectorUtils.provideGardenPlantingListViewModelFactory(requireContext())
val viewModel = ViewModelProviders.of(this, factory).get(GardenPlantingListViewModel::class.java)
```

**To**

```kotlin
private val viewModel: GardenPlantingListViewModel by viewModels {
        InjectorUtils.provideGardenPlantingListViewModelFactory(requireContext())
    }
```

Official documents can be viewed [here](https://developer.android.com/reference/kotlin/androidx/fragment/app/package-summary#viewmodels) .