### PR TITLE
Oberve LiveData with  Extension function

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -22,7 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
+import androidx.lifecycle.observe
 import com.google.samples.apps.sunflower.adapters.GardenPlantingAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentGardenBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
@@ -47,13 +47,13 @@ class GardenFragment : Fragment() {
     }
 
     private fun subscribeUi(adapter: GardenPlantingAdapter, binding: FragmentGardenBinding) {
-        viewModel.gardenPlantings.observe(viewLifecycleOwner, Observer { plantings ->
+        viewModel.gardenPlantings.observe(viewLifecycleOwner) { plantings ->
             binding.hasPlantings = !plantings.isNullOrEmpty()
-        })
+        }
 
-        viewModel.plantAndGardenPlantings.observe(viewLifecycleOwner, Observer { result ->
+        viewModel.plantAndGardenPlantings.observe(viewLifecycleOwner) { result ->
             if (!result.isNullOrEmpty())
                 adapter.submitList(result)
-        })
+        }
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -29,7 +29,7 @@ import androidx.core.app.ShareCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
+import androidx.lifecycle.observe
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
 import com.google.samples.apps.sunflower.databinding.FragmentPlantDetailBinding
@@ -63,13 +63,13 @@ class PlantDetailFragment : Fragment() {
             }
         }
 
-        plantDetailViewModel.plant.observe(this, Observer { plant ->
+        plantDetailViewModel.plant.observe(this) { plant ->
             shareText = if (plant == null) {
                 ""
             } else {
                 getString(R.string.share_text_plant, plant.name)
             }
-        })
+        }
 
         setHasOptionsMenu(true)
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantListFragment.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
+import androidx.lifecycle.observe
 import com.google.samples.apps.sunflower.adapters.PlantAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentPlantListBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
@@ -68,9 +68,14 @@ class PlantListFragment : Fragment() {
     }
 
     private fun subscribeUi(adapter: PlantAdapter) {
-        viewModel.plants.observe(viewLifecycleOwner, Observer { plants ->
+        viewModel.plants.observe(viewLifecycleOwner) { plants ->
+            /**
+             *  Plant may return null, but the [observe] extension function assumes it will not be null.
+             *  So there will be a warning（Condition `plants != null` is always `true`） here.
+             *  I am not sure if the database return data type should be defined as nullable, Such as `LiveData<List<Plant>?>` .
+             */
             if (plants != null) adapter.submitList(plants)
-        })
+        }
     }
 
     private fun updateData() {


### PR DESCRIPTION
I used the extension function `observe` in `LiveData` to make adjustments to the code in the project, which seems to be more in line with the `Kotlin` syntax, like this:

**From** 

```kotlin
viewModel.gardenPlantings.observe(viewLifecycleOwner, Observer { plantings ->
    binding.hasPlantings = !plantings.isNullOrEmpty()
})
```

**To**

```kotlin
viewModel.gardenPlantings.observe(viewLifecycleOwner) { plantings ->
    binding.hasPlantings = !plantings.isNullOrEmpty()
}
```