### PR TITLE
[FIX] Ambiguity return of  getGardenPlantingForPlant in GardenPlantingDao

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingDao.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/GardenPlantingDao.kt
@@ -35,7 +35,7 @@ interface GardenPlantingDao {
     fun getGardenPlanting(gardenPlantingId: Long): LiveData<GardenPlanting>
 
     @Query("SELECT * FROM garden_plantings WHERE plant_id = :plantId")
-    fun getGardenPlantingForPlant(plantId: String): LiveData<GardenPlanting>
+    fun getGardenPlantingForPlant(plantId: String): LiveData<GardenPlanting?>
 
     /**
      * This query will tell Room to query both the [Plant] and [GardenPlanting] tables and handle


### PR DESCRIPTION
The `getGardenPlantingForPlant` should return a `null` and then the `map` call or check (whatever) 
in `PlantDetailViewModel` could be meaningful and the warning of lint in IDE will be out.