### PR TITLE
Removed Google+ community reference since Google+ is shutdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ injection to better understand Sunflower's code without having to learn DI.
 Support
 -------
 
-- Google+ Community: https://plus.google.com/communities/105153134372062985968
 - Stack Overflow:
   - http://stackoverflow.com/questions/tagged/android
   - http://stackoverflow.com/questions/tagged/android-jetpack


### PR DESCRIPTION
This PR is regarding issue #419.

Removed reference and link to Google+ Community since Google+ is shutdown.