### PR TITLE
Add button to navigate to Plant List

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/GardenFragment.kt
@@ -23,12 +23,15 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
+import androidx.navigation.fragment.findNavController
 import com.google.samples.apps.sunflower.adapters.GardenPlantingAdapter
 import com.google.samples.apps.sunflower.databinding.FragmentGardenBinding
 import com.google.samples.apps.sunflower.utilities.InjectorUtils
 import com.google.samples.apps.sunflower.viewmodels.GardenPlantingListViewModel
 
 class GardenFragment : Fragment() {
+
+    private lateinit var binding: FragmentGardenBinding
 
     private val viewModel: GardenPlantingListViewModel by viewModels {
         InjectorUtils.provideGardenPlantingListViewModelFactory(requireContext())
@@ -39,11 +42,20 @@ class GardenFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val binding = FragmentGardenBinding.inflate(inflater, container, false)
+        binding = FragmentGardenBinding.inflate(inflater, container, false)
         val adapter = GardenPlantingAdapter()
         binding.gardenList.adapter = adapter
         subscribeUi(adapter, binding)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.addPlant.setOnClickListener {
+            val direction = GardenFragmentDirections.actionGardenFragmentToPlantListFragment()
+            findNavController().navigate(direction)
+        }
     }
 
     private fun subscribeUi(adapter: GardenPlantingAdapter, binding: FragmentGardenBinding) {

--- a/app/src/main/res/layout/fragment_garden.xml
+++ b/app/src/main/res/layout/fragment_garden.xml
@@ -42,14 +42,27 @@
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 tools:listitem="@layout/list_item_garden_planting"/>
 
-        <TextView
-                android:id="@+id/empty_garden"
+        <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:gravity="center"
-                android:text="@string/garden_empty"
-                android:textSize="24sp"
-                app:isGone="@{hasPlantings}"/>
+                android:orientation="vertical"
+                app:isGone="@{hasPlantings}">
+
+            <TextView
+                    android:id="@+id/empty_garden"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/garden_empty"
+                    android:textSize="24sp"/>
+
+            <Button
+                    android:id="@+id/add_plant"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/add_plant"/>
+
+        </LinearLayout>
 
     </FrameLayout>
 

--- a/app/src/main/res/navigation/nav_garden.xml
+++ b/app/src/main/res/navigation/nav_garden.xml
@@ -27,6 +27,13 @@
         tools:layout="@layout/fragment_garden">
 
         <action
+            android:id="@+id/action_garden_fragment_to_plant_list_fragment"
+            app:destination="@id/plant_list_fragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+        <action
             android:id="@+id/action_garden_fragment_to_plant_detail_fragment"
             app:destination="@id/plant_detail_fragment"
             app:enterAnim="@anim/slide_in_right"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,6 +21,7 @@
     <string name="plant_list_title">Pflanzenliste</string>
     <string name="plant_details_title">Details zur Pflanze</string>
     <string name="navigation_drawer_header_content_description">App Navigation</string>
+    <string name="add_plant">(translate me) Add plant</string>
     <string name="added_plant_to_garden">Pflanze wurde zum Garten hinzugefügt</string>
     <string name="garden_empty">Ihr Garten ist unbepflanzt</string>
     <string name="planted_date">%1$s gepflanzt in %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -21,6 +21,7 @@
     <string name="plant_list_title">Liste des plantes</string>
     <string name="plant_details_title">Détails sur la plante</string>
     <string name="navigation_drawer_header_content_description">Logo de l\'application du volet de navigation</string>
+    <string name="add_plant">(translate me) Add plant</string>
     <string name="added_plant_to_garden">Plante ajoutée à votre jardin</string>
     <string name="garden_empty">Votre jardin est vide</string>
     <string name="planted_date">%1$s planté(e) le %2$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -24,6 +24,7 @@
     <string name="menu_item_share_plant">Condividi</string>
     <string name="planted_date">%1$s piantata il %2$s</string>
     <string name="garden_empty">Il tuo giardino è vuoto</string>
+    <string name="add_plant">(translate me) Add plant</string>
     <string name="added_plant_to_garden">Pianta aggiunta al giardino</string>
     <string name="navigation_drawer_header_content_description">Logo dell\'intestazione di navigazione</string>
     <string name="share_text_plant">Controlla la pianta %s nell\'app Sunflower</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -21,6 +21,7 @@
     <string name="plant_list_title">植物のリスト</string>
     <string name="plant_details_title">植物の詳細</string>
     <string name="navigation_drawer_header_content_description">アプリナビゲーション</string>
+    <string name="add_plant">(translate me) Add plant</string>
     <string name="added_plant_to_garden">植物が庭に追加されました</string>
     <string name="garden_empty">あなたの庭に植物はありません</string>
     <string name="planted_date">%1$s は %2$s に植わっています</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -21,6 +21,7 @@
     <string name="plant_list_title">植物目录</string>
     <string name="plant_details_title">植物介绍</string>
     <string name="navigation_drawer_header_content_description">导航抽屉页眉</string>
+    <string name="add_plant">(translate me) Add plant</string>
     <string name="added_plant_to_garden">添加了新植物</string>
     <string name="garden_empty">花园里还没有植物</string>
     <string name="planted_date">%1$s 种植于 %2$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,6 +21,7 @@
     <string name="plant_list_title">植物目錄</string>
     <string name="plant_details_title">植物介紹</string>
     <string name="navigation_drawer_header_content_description">導航抽屜頁眉</string>
+    <string name="add_plant">(translate me) Add plant</string>
     <string name="added_plant_to_garden">添加了新植物</string>
     <string name="garden_empty">花園裡還沒有植物</string>
     <string name="planted_date">%1$s 種植於 %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,8 @@
     <string name="plant_list_title" translation_description="Title for the plant list screen where the user can see a list of plants available to add to their garden.">Plant list</string>
     <string name="plant_details_title" translation_description="Title for the plant details screen where the user can see the details for a specific plant.">Plant details</string>
     <string name="navigation_drawer_header_content_description" translation_description="Content description for the image that is shown at the top of the navigation drawer.">Navigation drawer header logo</string>
-    <string name="added_plant_to_garden" translation_description="Confirmation text that is shown when a user adds a plant to their graden.">Added plant to garden</string>
+    <string name="add_plant" translation_description="Button text that prompts user to navigate to the Plant List to add plants to their empty garden.">Add plant</string>
+    <string name="added_plant_to_garden" translation_description="Confirmation text that is shown when a user adds a plant to their empty garden.">Added plant to garden</string>
     <string name="garden_empty" translation_description="Text that is shown on the 'My Garden' screen when no plants have been added to the user's garden">Your garden is empty</string>
     <string name="planted_date" translation_description="Text with placeholders that indicates when the plant was planted. Example: 'Sunflower planted on May 24, 2018'.">%1$s planted on %2$s</string>
     <string name="menu_item_share_plant" translation_description="The label for the Share menu item">Share</string>


### PR DESCRIPTION
When the user's garden is empty, add a button prompting them to navigate to the Plant List.

This also adds a new string and some placeholder string translations.

Updated styling will be implemented in a future commit.

<img src="https://user-images.githubusercontent.com/97128/59638549-9f04b900-910d-11e9-95b1-438df7f1bf5f.png" width=250>
