### PR TITLE
Change Plant List Page to use GridLayout

### DIFF
--- a/app/src/main/res/layout/fragment_garden.xml
+++ b/app/src/main/res/layout/fragment_garden.xml
@@ -39,7 +39,8 @@
                 android:paddingLeft="@dimen/margin_normal"
                 android:paddingRight="@dimen/margin_normal"
                 app:isGone="@{!hasPlantings}"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:spanCount="2"
                 tools:listitem="@layout/list_item_garden_planting"/>
 
         <TextView

--- a/app/src/main/res/layout/fragment_garden.xml
+++ b/app/src/main/res/layout/fragment_garden.xml
@@ -40,7 +40,7 @@
                 android:paddingRight="@dimen/margin_normal"
                 app:isGone="@{!hasPlantings}"
                 app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                app:spanCount="2"
+                app:spanCount="@integer/grid_columns"
                 tools:listitem="@layout/list_item_garden_planting"/>
 
         <TextView

--- a/app/src/main/res/layout/fragment_plant_list.xml
+++ b/app/src/main/res/layout/fragment_plant_list.xml
@@ -27,7 +27,7 @@
             android:paddingLeft="@dimen/margin_normal"
             android:paddingRight="@dimen/margin_normal"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:spanCount="2"
+            app:spanCount="@integer/grid_columns"
             tools:context="com.google.samples.apps.sunflower.GardenActivity"
             tools:listitem="@layout/list_item_plant" />
 

--- a/app/src/main/res/layout/fragment_plant_list.xml
+++ b/app/src/main/res/layout/fragment_plant_list.xml
@@ -26,7 +26,8 @@
             android:clipToPadding="false"
             android:paddingLeft="@dimen/margin_normal"
             android:paddingRight="@dimen/margin_normal"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:spanCount="2"
             tools:context="com.google.samples.apps.sunflower.GardenActivity"
             tools:listitem="@layout/list_item_plant" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -34,4 +34,7 @@
     <dimen name="navigation_drawer_header_height">192dp</dimen>
     <dimen name="navigation_drawer_header_padding">16dp</dimen>
     <dimen name="navigation_drawer_image_width">100dp</dimen>
+
+    <!-- Number of columns for garden and plant list grid -->
+    <integer name="grid_columns">2</integer>
 </resources>


### PR DESCRIPTION
Changed XML file of Plant List fragment to use GridLayout Manager instead of LinearLayoutManager, and changed GridLayout to use two columns instead of one. This is a setup PR to update the Plant List page to use Material Design cards.

<img width="392" alt="Screen Shot 2019-06-17 at 2 55 22 PM" src="https://user-images.githubusercontent.com/8967505/59639391-ff94f580-910f-11e9-8f56-e9a050905e76.png">

<img width="400" alt="Screen Shot 2019-06-17 at 2 55 36 PM" src="https://user-images.githubusercontent.com/8967505/59639392-ff94f580-910f-11e9-8dfe-3731aa09ea73.png">
