### PR TITLE
Added Menu Buttons to Plant Detail Page

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -63,8 +63,12 @@ class PlantDetailFragment : Fragment() {
                 Snackbar.make(view, R.string.added_plant_to_garden, Snackbar.LENGTH_LONG).show()
             }
 
-            back.setOnClickListener {
-                it.findNavController().navigateUp()
+            back.setOnClickListener { view ->
+                view.findNavController().navigateUp()
+            }
+
+            share.setOnClickListener {
+                createShareIntent()
             }
         }
 
@@ -90,24 +94,29 @@ class PlantDetailFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.action_share -> {
-                val shareIntent = ShareCompat.IntentBuilder.from(activity)
-                    .setText(shareText)
-                    .setType("text/plain")
-                    .createChooserIntent()
-                    .apply {
-                        // https://android-developers.googleblog.com/2012/02/share-with-intents.html
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            // If we're on Lollipop, we can open the intent as a document
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
-                        } else {
-                            // Else, we will use the old CLEAR_WHEN_TASK_RESET flag
-                            addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET)
-                        }
-                    }
-                startActivity(shareIntent)
+                createShareIntent()
                 return true
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    @Suppress("DEPRECATION")
+    fun createShareIntent() {
+        val shareIntent = ShareCompat.IntentBuilder.from(activity)
+                .setText(shareText)
+                .setType("text/plain")
+                .createChooserIntent()
+                .apply {
+                    // https://android-developers.googleblog.com/2012/02/share-with-intents.html
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        // If we're on Lollipop, we can open the intent as a document
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+                    } else {
+                        // Else, we will use the old CLEAR_WHEN_TASK_RESET flag
+                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET)
+                    }
+                }
+        startActivity(shareIntent)
     }
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -30,6 +30,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
 import com.google.samples.apps.sunflower.databinding.FragmentPlantDetailBinding
@@ -63,7 +64,7 @@ class PlantDetailFragment : Fragment() {
             }
 
             back.setOnClickListener {
-                fragmentManager?.popBackStackImmediate()
+                it.findNavController().navigateUp()
             }
         }
 

--- a/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/PlantDetailFragment.kt
@@ -61,6 +61,10 @@ class PlantDetailFragment : Fragment() {
                 plantDetailViewModel.addPlantToGarden()
                 Snackbar.make(view, R.string.added_plant_to_garden, Snackbar.LENGTH_LONG).show()
             }
+
+            back.setOnClickListener {
+                fragmentManager?.popBackStackImmediate()
+            }
         }
 
         plantDetailViewModel.plant.observe(this) { plant ->

--- a/app/src/main/res/drawable/ic_arrow_back_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_back_black_24dp.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2018 Google LLC
+  ~ Copyright 2019 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,13 +14,12 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <color name="colorBackground">#49bb79</color>
-    <color name="colorOnPrimary">#ffff63</color>
-    <color name="colorPrimary">#49bb79</color>
-    <color name="colorPrimaryDark">#DE2E2E2E</color>
-    <color name="colorAccent">#FF4081</color>
-    <color name="colorSurface">#FAFAFA</color>
-    <color name="colorSecondary">#FAFAFA</color>
-    <color name="colorOnSurface">#f1f2f6</color>
-</resources>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_plant_detail.xml
+++ b/app/src/main/res/layout/fragment_plant_detail.xml
@@ -62,18 +62,20 @@
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 
             <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            android:background="@color/colorSurface">
+
+            <TextView
                 android:layout_width="match_parent"
-                android:layout_height="?actionBarSize">
+                android:layout_height="?attr/actionBarSize"
+                android:gravity="center"
+                android:text="@{viewModel.plant.name}"
+                android:textColor="@color/colorPrimaryDark"
+                android:textSize="@dimen/font_large" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    android:gravity="center"
-                    android:text="@{viewModel.plant.name}"
-                    android:textSize="@dimen/font_large" />
-
-            </androidx.appcompat.widget.Toolbar>
+        </androidx.appcompat.widget.Toolbar>
 
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -95,7 +97,6 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin_small"
-                    android:layout_marginTop="@dimen/margin_normal"
                     android:layout_marginEnd="@dimen/margin_small"
                     android:gravity="center_horizontal"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -124,11 +125,35 @@
         </androidx.core.widget.NestedScrollView>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/back"
+            style="@style/Widget.MaterialComponents.FloatingActionButton"
+            android:layout_width="@dimen/detail_header_fab_size"
+            android:layout_height="@dimen/detail_header_fab_size"
+            android:layout_margin="@dimen/margin_small"
+            android:layout_gravity="start"
+            app:elevation="@dimen/detail_header_fab_elevation"
+            app:borderWidth="0dp"
+            app:fabCustomSize="@dimen/detail_header_fab_size"
+            app:srcCompat="@drawable/ic_arrow_back_black_24dp" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/share"
+            style="@style/Widget.MaterialComponents.FloatingActionButton"
+            android:layout_width="@dimen/detail_header_fab_size"
+            android:layout_height="@dimen/detail_header_fab_size"
+            android:layout_margin="@dimen/margin_small"
+            android:layout_gravity="end"
+            app:elevation="@dimen/detail_header_fab_elevation"
+            app:borderWidth="0dp"
+            app:fabCustomSize="@dimen/detail_header_fab_size"
+            app:srcCompat="@drawable/ic_share" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab"
             style="@style/Widget.MaterialComponents.FloatingActionButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_margin"
+            android:layout_marginEnd="@dimen/fab_margin"
             android:tint="@android:color/white"
             app:isGone="@{viewModel.isPlanted}"
             app:layout_anchor="@id/appbar"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -36,6 +36,10 @@
     <dimen name="card_elevation">2dp</dimen>
     <dimen name="card_corner_radius">12dp</dimen>
 
+    <dimen name="detail_header_fab_size">32dp</dimen>
+    <dimen name="detail_header_fab_margin">12dp</dimen>
+    <dimen name="detail_header_fab_elevation">4dp</dimen>
+
     <dimen name="font_large">24sp</dimen>
 
     <!-- Number of columns for garden and plant list grid -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,6 +23,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:colorBackground">@color/colorBackground</item>
+        <item name="colorSecondary">@color/colorSecondary</item>
     </style>
 
     <style name="AppTheme" parent="BaseAppTheme"/>


### PR DESCRIPTION
Added and styled back and share menu buttons to plant detail page. Back button takes you to previous fragment. Share button does not have any functionality currently.

![image](https://user-images.githubusercontent.com/8967505/59957513-df39a380-944d-11e9-8c81-3a379b2c70c7.png)
![Screenshot_1561164868](https://user-images.githubusercontent.com/8967505/59957488-a7326080-944d-11e9-95d0-705fce745af1.png)


