### PR TITLE
Toolbar text color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -40,7 +40,7 @@
     <style name="Theme.Sunflower.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light"/>
 
     <style name="TextAppearance.Sunflower.Toolbar.Text" parent="TextAppearance.MaterialComponents.Headline5" >
-        <item name="android:textColor">?attr/colorPrimaryDark</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Fixed toolbar Text color, previously was pointing to wrong color element.

![Screenshot_1565024940](https://user-images.githubusercontent.com/8967505/62482099-1c8d9280-b769-11e9-9697-040ca1528b4b.png)
![Screenshot_1565024963](https://user-images.githubusercontent.com/8967505/62482100-1d262900-b769-11e9-9884-5707c19b9bfd.png)
