### PR TITLE
[ Fix ]: App Crash when scroll to page 2 in Gallery Screen

### DIFF
--- a/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashRepository.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/data/UnsplashRepository.kt
@@ -27,7 +27,7 @@ class UnsplashRepository @Inject constructor(private val service: UnsplashServic
 
     fun getSearchResultStream(query: String): Flow<PagingData<UnsplashPhoto>> {
         return Pager(
-            config = PagingConfig(enablePlaceholders = false, pageSize = NETWORK_PAGE_SIZE),
+            config = PagingConfig(enablePlaceholders = false, pageSize = NETWORK_PAGE_SIZE, initialLoadSize = NETWORK_PAGE_SIZE),
             pagingSourceFactory = { UnsplashPagingSource(service, query) }
         ).flow
     }


### PR DESCRIPTION
When the first page is loaded, pageSize=75
https://api.unsplash.com/search/photos?query=Apple&page=1&per_page=75

When the second page is loaded, pageSize=25
https://api.unsplash.com/search/photos?query=Apple&page=2&per_page=25

Duplicate data on the first and second pages

```
FATAL EXCEPTION: main 
Process: com.google.samples.apps.sunflower, PID: 8802
java.lang.IllegalArgumentException: Key "P2X7NDx_GP0" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```
So App Crash when scroll to page 2 in Gallery Screen

Here's my solution, Specify the value of initialLoadSize explicitly
```
fun getSearchResultStream(query: String): Flow<PagingData<UnsplashPhoto>> {
      return Pager(
          config = PagingConfig(enablePlaceholders = false, pageSize = NETWORK_PAGE_SIZE, initialLoadSize = NETWORK_PAGE_SIZE),
          pagingSourceFactory = { UnsplashPagingSource(service, query) }
      ).flow
  }
```