### PR TITLE
Refactor WorkManager for Hilt dependency injection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,7 @@ androidComponents {
 dependencies {
   ksp(libs.androidx.room.compiler)
   ksp(libs.hilt.android.compiler)
+  ksp(libs.hilt.ext.compiler)
   implementation(libs.androidx.core.ktx)
   implementation(libs.androidx.lifecycle.livedata.ktx)
   implementation(libs.androidx.lifecycle.viewmodel.ktx)
@@ -127,6 +128,7 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.hilt.android)
   implementation(libs.hilt.navigation.compose)
+  implementation(libs.hilt.ext.work)
   implementation(libs.androidx.profileinstaller)
 
   // Compose

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/testdobules/TestPlantDao.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/testdobules/TestPlantDao.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.testdobules
+
+import com.google.samples.apps.sunflower.data.Plant
+import com.google.samples.apps.sunflower.data.PlantDao
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+
+class TestPlantDao : PlantDao {
+
+    private val entitiesFlow = MutableStateFlow(emptyList<Plant>())
+
+    override fun getPlants(): Flow<List<Plant>> = entitiesFlow
+
+    override fun getPlantsWithGrowZoneNumber(growZoneNumber: Int): Flow<List<Plant>> =
+        getPlants().map { plants ->
+            plants.filter { plant -> plant.growZoneNumber == growZoneNumber }
+        }
+
+    override fun getPlant(plantId: String): Flow<Plant> =
+        getPlants().map { plants ->
+            plants.first { plant -> plant.plantId == plantId }
+        }
+
+    override suspend fun upsertAll(plants: List<Plant>) {
+        entitiesFlow.update { oldValues ->
+            (oldValues + plants).distinctBy(Plant::plantId)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/SeedDatabaseWorkerTest.kt
@@ -17,44 +17,36 @@
 package com.google.samples.apps.sunflower.worker
 
 import android.content.Context
-import android.util.Log
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.work.Configuration
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.work.ListenableWorker.Result
-import androidx.work.WorkManager
-import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.TestListenableWorkerBuilder
-import androidx.work.testing.WorkManagerTestInitHelper
 import androidx.work.workDataOf
+import com.google.samples.apps.sunflower.testdobules.TestPlantDao
+import com.google.samples.apps.sunflower.data.PlantDao
+import com.google.samples.apps.sunflower.utilities.AssetManager
+import com.google.samples.apps.sunflower.utilities.JsonAssetManager
 import com.google.samples.apps.sunflower.utilities.PLANT_DATA_FILENAME
 import com.google.samples.apps.sunflower.workers.SeedDatabaseWorker
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class RefreshMainDataWorkTest {
-    private lateinit var workManager: WorkManager
+
     private lateinit var context: Context
-    private lateinit var configuration: Configuration
+    private lateinit var plantDao: PlantDao
+    private lateinit var assetManager: AssetManager
+    private lateinit var testSeedDatabaseWorkerFactory: TestSeedDatabaseWorkerFactory
 
     @Before
     fun setup() {
-        // Configure WorkManager
-        configuration = Configuration.Builder()
-            // Set log level to Log.DEBUG to make it easier to debug
-            .setMinimumLoggingLevel(Log.DEBUG)
-            // Use a SynchronousExecutor here to make it easier to write tests
-            .setExecutor(SynchronousExecutor())
-            .build()
-
-        // Initialize WorkManager for instrumentation tests.
-        context = InstrumentationRegistry.getInstrumentation().targetContext
-        WorkManagerTestInitHelper.initializeTestWorkManager(context, configuration)
-        workManager = WorkManager.getInstance(context)
+        context = ApplicationProvider.getApplicationContext()
+        plantDao = TestPlantDao()
+        assetManager = JsonAssetManager(context)
+        testSeedDatabaseWorkerFactory = TestSeedDatabaseWorkerFactory(plantDao, assetManager)
     }
 
     @Test
@@ -63,12 +55,16 @@ class RefreshMainDataWorkTest {
         val worker = TestListenableWorkerBuilder<SeedDatabaseWorker>(
             context = context,
             inputData = workDataOf(SeedDatabaseWorker.KEY_FILENAME to PLANT_DATA_FILENAME)
-        ).build()
+        )
+            .setWorkerFactory(testSeedDatabaseWorkerFactory)
+            .build()
 
-        // Start the work synchronously
-        val future = worker.startWork()
-        val result = future.get()
+        runTest {
+            // Start the work synchronously
+            val result = worker.doWork()
 
-        assertThat(result, `is`(Result.Success()))
+            assert(plantDao.getPlants().first().isNotEmpty())
+            assertThat(result, `is`(Result.Success()))
+        }
     }
 }

--- a/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/TestWorkerFactory.kt
+++ b/app/src/androidTest/java/com/google/samples/apps/sunflower/worker/TestWorkerFactory.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.worker
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import com.google.samples.apps.sunflower.data.PlantDao
+import com.google.samples.apps.sunflower.utilities.AssetManager
+import com.google.samples.apps.sunflower.workers.SeedDatabaseWorker
+
+class TestSeedDatabaseWorkerFactory(
+    private val plantDao: PlantDao,
+    private val assertManager: AssetManager
+) : WorkerFactory() {
+
+    override fun createWorker(
+        appContext: Context,
+        workerClassName: String,
+        workerParameters: WorkerParameters
+    ): ListenableWorker? =
+        if (workerClassName == SeedDatabaseWorker::class.java.name) {
+            SeedDatabaseWorker(appContext, workerParameters, plantDao, assertManager)
+        } else {
+            null
+        }
+
+}

--- a/app/src/main/java/com/google/samples/apps/sunflower/MainApplication.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/MainApplication.kt
@@ -17,13 +17,19 @@
 package com.google.samples.apps.sunflower
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
 class MainApplication : Application(), Configuration.Provider {
+
+  @Inject lateinit var workFactory: HiltWorkerFactory
+
   override val workManagerConfiguration: Configuration
     get() = Configuration.Builder()
       .setMinimumLoggingLevel(if (BuildConfig.DEBUG) android.util.Log.DEBUG else android.util.Log.ERROR)
+      .setWorkerFactory(workFactory)
       .build()
 }

--- a/app/src/main/java/com/google/samples/apps/sunflower/di/AssetModule.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/di/AssetModule.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.di
+
+import com.google.samples.apps.sunflower.utilities.AssetManager
+import com.google.samples.apps.sunflower.utilities.JsonAssetManager
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface AssetModule {
+
+    @Binds
+    fun bindsAssetManager(impl: JsonAssetManager): AssetManager
+}

--- a/app/src/main/java/com/google/samples/apps/sunflower/utilities/AssetManager.kt
+++ b/app/src/main/java/com/google/samples/apps/sunflower/utilities/AssetManager.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.sunflower.utilities
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.InputStream
+import javax.inject.Inject
+
+interface AssetManager {
+    fun open(fileName: String): InputStream
+}
+
+class JsonAssetManager @Inject constructor(
+    @ApplicationContext private val context: Context
+): AssetManager {
+
+    override fun open(fileName: String): InputStream =
+        context.assets.open(fileName)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ gradle-versions = "0.51.0"
 gson = "2.9.0"
 guava = "33.0.0-jre"
 hilt = "2.50"
-hiltNavigationCompose = "1.1.0"
+hiltExt = "1.1.0"
 junit = "4.13.2"
 kotlin = "1.9.22"
 ksp = "1.9.22-1.0.17"
@@ -104,7 +104,9 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltExt" }
+hilt-ext-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltExt" }
+hilt-ext-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltExt" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
Separated the dependencies of Assets and DB previously used in WorkManager and migrated to receive them through Hilt injection. Also, updated the related test code accordingly.